### PR TITLE
Add a new dockerfile for rhel9

### DIFF
--- a/.github/workflows/build_and_publish_docker.yaml
+++ b/.github/workflows/build_and_publish_docker.yaml
@@ -3,14 +3,11 @@ name: build and publish docker images
 
 on:
   workflow_dispatch:
-  push:
-    branch:
-      - 'main'
   schedule:
     - cron: '0 0 * * FRI'
 
 jobs:
-  build_images:
+  build_images_rhel8:
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -29,6 +26,29 @@ jobs:
       - uses: docker/build-push-action@v3
         with:
           push: true
+          tags: ghcr.io/${{ github.repository_owner }}/ros:${{ matrix.ros_distro }}-rhel
+          build-args: |
+            ROS_DISTRO=${{ matrix.ros_distro }}
+  build_images_rhel9:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    strategy:
+      matrix:
+        ros_distro: ['iron', 'rolling']
+    steps:
+      - uses: actions/checkout@v3
+      - uses: docker/setup-buildx-action@v2
+      - uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - uses: docker/build-push-action@v3
+        with:
+          push: true
+          file: Dockerfile.rhel9
           tags: ghcr.io/${{ github.repository_owner }}/ros:${{ matrix.ros_distro }}-rhel
           build-args: |
             ROS_DISTRO=${{ matrix.ros_distro }}

--- a/.github/workflows/build_and_publish_docker.yaml
+++ b/.github/workflows/build_and_publish_docker.yaml
@@ -14,7 +14,7 @@ jobs:
       packages: write
     strategy:
       matrix:
-        ros_distro: ['galactic', 'humble', 'rolling']
+        ros_distro: ['galactic', 'humble']
     steps:
       - uses: actions/checkout@v3
       - uses: docker/setup-buildx-action@v2

--- a/.github/workflows/build_and_publish_docker.yaml
+++ b/.github/workflows/build_and_publish_docker.yaml
@@ -14,7 +14,7 @@ jobs:
       packages: write
     strategy:
       matrix:
-        ros_distro: ['galactic', 'humble']
+        ros_distro: ['humble']
     steps:
       - uses: actions/checkout@v3
       - uses: docker/setup-buildx-action@v2

--- a/Dockerfile.rhel9
+++ b/Dockerfile.rhel9
@@ -1,4 +1,4 @@
-FROM almalinux:8
+FROM almalinux:9
 ARG ROS_DISTRO=rolling
 
 # install ros
@@ -12,7 +12,7 @@ RUN dnf install \
   langpacks-en \
   git \
   -y --refresh
-RUN dnf config-manager --set-enabled powertools 
+RUN dnf config-manager --set-enabled crb 
 
 ENV ROS_DISTRO=${ROS_DISTRO}
 RUN dnf install -y ros-${ROS_DISTRO}-ros-base \

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-This is a sample Dockerfile that show ros2 installed on almalinux based on the [binary installation instructions at docs.ros.org](https://docs.ros.org/en/galactic/Installation/RHEL-Install-Binary.html). The most recent public build can be found with the docker tag: ghcr.io/ros-controls/ros:<ROS_DISTRO>-rhel where <ROS_DISTRO> is replaced with the ros distribution you are targeting.
+This is a sample Dockerfile that show ros2 installed on almalinux based on the [binary installation instructions at docs.ros.org](https://docs.ros.org/en/rolling/Installation/RHEL-Install-RPMs.html). The most recent public build can be found with the docker tag: `ghcr.io/ros-controls/ros:<ROS_DISTRO>-rhel` where `<ROS_DISTRO>` is replaced with the ros distribution you are targeting.
 
 The image tries to emulate the official ros2 images but on alma (downstream RHEL) linux. Therefore a few extra packages can be found within this repo that are not mentioned at the above link, i.e. colcon, etc.
 


### PR DESCRIPTION
Starting with iron, RHEL9 is the supported RHEL platform.

This should fix the [rolling workflow of ros2_control ](https://github.com/ros-controls/ros2_control/actions/workflows/rolling-rhel-binary-build.yml)